### PR TITLE
feat: scaffold web app with onboarding form

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+NEXTAUTH_SECRET="changeme"
+NEXTAUTH_URL="http://localhost:3000"

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ dist
 .next
 .expo
 .env*
+!.env.example
 .DS_Store

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,0 +1,15 @@
+import "./globals.css";
+import type { ReactNode } from "react";
+
+export const metadata = {
+  title: "Web App",
+  description: "Dog lab web app",
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body className="min-h-screen bg-white text-black">{children}</body>
+    </html>
+  );
+}

--- a/apps/web/app/onboarding/page.tsx
+++ b/apps/web/app/onboarding/page.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useState } from "react";
+
+export default function OnboardingPage() {
+  const [name, setName] = useState("");
+  const [weightKg, setWeightKg] = useState("");
+
+  const weight = parseFloat(weightKg);
+  const rer = weight > 0 ? 70 * Math.pow(weight, 0.75) : 0;
+
+  return (
+    <main className="p-4 space-y-4">
+      <form className="space-y-4">
+        <div>
+          <label className="block mb-1" htmlFor="name">Name</label>
+          <input
+            id="name"
+            className="border px-2 py-1 w-full"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+        </div>
+        <div>
+          <label className="block mb-1" htmlFor="weight">Weight (kg)</label>
+          <input
+            id="weight"
+            type="number"
+            className="border px-2 py-1 w-full"
+            value={weightKg}
+            onChange={(e) => setWeightKg(e.target.value)}
+          />
+        </div>
+      </form>
+      {weightKg && (
+        <p className="mt-4">RER: {rer.toFixed(2)}</p>
+      )}
+    </main>
+  );
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,0 +1,7 @@
+export default function Page() {
+  return (
+    <main className="p-4">
+      <h1 className="text-2xl font-bold">Welcome</h1>
+    </main>
+  );
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@dog/web",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "^14.0.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "autoprefixer": "^10.4.16",
+    "postcss": "^8.4.31",
+    "tailwindcss": "^3.4.1"
+  }
+}

--- a/apps/web/postcss.config.js
+++ b/apps/web/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -1,0 +1,14 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: ["./app/**/*.{ts,tsx}"],
+  presets: [
+    // TODO: extend shared preset when available
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- scaffold Next.js 14 app in `apps/web` with Tailwind and standard PostCSS config
- add onboarding form computing RER from weight
- document NEXTAUTH variables in `.env.example`

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.0.0.tgz; Proxy response (403) !== 200 when HTTP Tunneling)*
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.0.0.tgz; Proxy response (403) !== 200 when HTTP Tunneling)*

------
https://chatgpt.com/codex/tasks/task_b_68b0ba979c5c8328bf220db9fde66f34