### PR TITLE
ci: add GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - run: corepack enable && corepack prepare pnpm@9 --activate
+      - run: pnpm install --no-frozen-lockfile
+      - run: pnpm turbo run lint --continue
+      - run: pnpm turbo run typecheck --continue
+      - run: pnpm turbo run build --continue


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run lint, typecheck, and build using pnpm

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.0.0.tgz; for troubleshooting help, see https://github.com/nodejs/corepack#troubleshooting)*

------
https://chatgpt.com/codex/tasks/task_b_68b0baad9e348328a7e8f75a77d14c6d