### PR TITLE
feat: add nutrient standards seed script

### DIFF
--- a/scripts/seed/README.md
+++ b/scripts/seed/README.md
@@ -1,0 +1,14 @@
+# Seed
+
+Import nutrient standards from CSV files into the database.
+
+## Usage
+
+1. Place CSV files in the `data/` directory.
+2. Run the seed script:
+   ```bash
+   pnpm exec ts-node scripts/seed/seed.ts
+   ```
+   This will parse the CSVs and upsert records via Prisma.
+
+Each CSV must include the columns `nutrient`, `unit`, `min`, and `max`.

--- a/scripts/seed/data/aafco_2014_dogs_complete.csv
+++ b/scripts/seed/data/aafco_2014_dogs_complete.csv
@@ -1,0 +1,1 @@
+nutrient,unit,min,max

--- a/scripts/seed/data/fediaf_2024_dogs_table_III_3b_full.csv
+++ b/scripts/seed/data/fediaf_2024_dogs_table_III_3b_full.csv
@@ -1,0 +1,1 @@
+nutrient,unit,min,max

--- a/scripts/seed/seed.ts
+++ b/scripts/seed/seed.ts
@@ -1,0 +1,62 @@
+import { PrismaClient } from '@prisma/client';
+import { readFileSync } from 'fs';
+import path from 'path';
+import { parse } from 'csv-parse/sync';
+
+const prisma = new PrismaClient();
+
+interface RequirementRow {
+  nutrient: string;
+  unit: string;
+  min?: string;
+  max?: string;
+}
+
+async function importStandard(name: string, filename: string) {
+  const filePath = path.join(__dirname, 'data', filename);
+  const content = readFileSync(filePath, 'utf8');
+  const rows: RequirementRow[] = parse(content, { columns: true, skip_empty_lines: true });
+
+  const standard = await prisma.nutrientStandard.upsert({
+    where: { name },
+    update: {},
+    create: { name },
+  });
+
+  for (const row of rows) {
+    await prisma.nutrientRequirement.upsert({
+      where: {
+        standardId_nutrient: {
+          standardId: standard.id,
+          nutrient: row.nutrient,
+        },
+      },
+      update: {
+        unit: row.unit,
+        min: row.min ? Number(row.min) : null,
+        max: row.max ? Number(row.max) : null,
+      },
+      create: {
+        standardId: standard.id,
+        nutrient: row.nutrient,
+        unit: row.unit,
+        min: row.min ? Number(row.min) : null,
+        max: row.max ? Number(row.max) : null,
+      },
+    });
+  }
+}
+
+async function main() {
+  await importStandard('AAFCO 2014 Dogs', 'aafco_2014_dogs_complete.csv');
+  await importStandard('FEDIAF 2024 Dogs', 'fediaf_2024_dogs_table_III_3b_full.csv');
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
## Summary
- add seed script to import nutrient standards
- include placeholder AAFCO and FEDIAF CSVs and usage docs

## Testing
- `pnpm lint` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*
- `pnpm test` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*

------
https://chatgpt.com/codex/tasks/task_b_68b0bac159548328836443369f3cbad6